### PR TITLE
Fix: Add missing model for fastapi

### DIFF
--- a/src/github_oidc/server.py
+++ b/src/github_oidc/server.py
@@ -74,6 +74,8 @@ class GithubOIDC(SecurityBase):
         ],
     ):
         self.audience = audience
+        self.model = oidc
+        self.scheme_name = self.__class__.__name__
 
     async def __call__(
         self, authorization: Annotated[str, Security(oidc)]


### PR DESCRIPTION
Fixes:
``` 
"fastapi/openapi/utils.py", line 87, in get_openapi_security_definitions
    security_requirement.security_scheme.model,
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'GithubOIDC' object has no attribute 'model'
```

When generating openapi docs (swagger).
